### PR TITLE
Linux support

### DIFF
--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -29,7 +29,6 @@ import {
 } from "./utils.js";
 import { LATEST_MOD_RELEASE_URL, YM_RELEASE_METADATA_URL } from '../constants/urls.js';
 
-
 const State = getState();
 const logger = new Logger("patcher");
 
@@ -228,8 +227,6 @@ async function downloadAsar(callback) {
     );
 
 }
-
-
 
 async function copyFile(target, dest) {
     try {

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -314,8 +314,13 @@ export async function isInstallPossible(callback) {
     }
 
     if (isLinux) {
-        callback(0, "Linux is not supported yet.");
-        return { status: false, request: '' };
+        const ymAsarPath = getYMAsarDefaultPath();
+        if (!ymAsarPath) {
+            callback(0, "Can't find Yandex Music application in default path: " + YM_ASAR_PATH);
+            return { status: false, request: Events.REQUEST_YM_PATH };
+        }
+        callback(0, "Yandex Music application found: " + ymAsarPath);
+        return { status: true, request: null };
     }
 
     const isLegacyYMInstalled = await checkIfLegacyYMInstalled();

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -218,7 +218,7 @@ async function downloadAsar(callback) {
 
     const downloadPath = shouldDecompress ? (compressionType === 'zst' ? ASAR_ZST_TMP_PATH : ASAR_GZ_TMP_PATH) : ASAR_TMP_PATH;
 
-    await downloadFile(url, path.join(TMP_PATH, downloadPath),
+    await downloadFile(url, path.join(downloadPath),
         (progress, label) => {
             callback(progress*0.8, label);
         }

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -37,7 +37,7 @@ const zstdDecompressPromise = zlib.zstdDecompress ? promisify(zlib.zstdDecompres
 
 const DEFAULT_YM_PATH = {
     darwin: path.join('/Applications', 'Яндекс Музыка.app'),
-    linux: '',
+    linux: path.join('/opt', 'Яндекс Музыка'),
     win32: path.join(process?.env?.LOCALAPPDATA ?? '' , 'Programs', 'YandexMusic'),
 }
 

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -15,6 +15,7 @@ import Events from "../types/Events.js";
 import PatchTypes from '../types/PatchTypes.js';
 import { ASAR_ZST_TMP_PATH, ASAR_GZ_TMP_PATH, ASAR_TMP_PATH, EXTRACTED_ENTITLEMENTS_PATH, TMP_PATH, ASAR_TMP_BACKUP_PATH, YM_EXE_TMP_BACKUP_PATH } from '../constants/paths.js';
 import { Logger } from "./Logger.js";
+import { execFile } from 'child_process';
 
 import {
     checkIfLegacyYMInstalled,
@@ -50,6 +51,8 @@ const resolveAsarPath = (appPath, platform) => {
         return path.join(appPath, 'resources', 'app.asar');
     }
 }
+
+const execFileAsync = promisify(execFile);
 
 let YM_PATH = DEFAULT_YM_PATH[os.platform];
 let INFO_PLIST_PATH = path.join(YM_PATH, 'Contents', 'Info.plist');
@@ -229,12 +232,28 @@ async function downloadAsar(callback) {
 
 
 async function copyFile(target, dest) {
-    await fso.promises.copyFile(target, dest);
+    try {
+        await fso.promises.copyFile(target, dest);
+    } catch (error) {
+        if (process.platform === 'linux' && error.code === 'EACCES') {
+            await execFileAsync('pkexec', ['cp', target, dest]);
+        } else {
+            logger.error('File copying failed:', error);
+        }
+    }
 }
 
 async function createDirIfNotExist(target) {
-    if(!fs.existsSync(target)){
-        await fsp.mkdir(target);
+    if (!fs.existsSync(target)) {
+        try {
+            await fsp.mkdir(target);
+        } catch (error) {
+            if (process.platform === 'linux' && error.code === 'EACCES') {
+                await execFileAsync('pkexec', ['mkdir', '-p', target]);
+            } else {
+                logger.error('Directory creation failed:', error)
+            }
+        }
     }
 }
 

--- a/src/main/modules/utils.js
+++ b/src/main/modules/utils.js
@@ -45,7 +45,9 @@ export async function getYandexMusicProcesses() {
         try {
             const command = `pgrep -fa "yandexmusic"`
             const { stdout } = await execAsync(command, { encoding: 'utf8' })
-            const processes = stdout.split('\n').filter(line => line.trim() !== '').filter(line => !line.includes('pgrep'))
+            const processes = stdout.split('\n')
+                .filter(line => line.trim() !== '')
+                .filter(line => !['pgrep', 'yandexmusicmodpatcher', 'YandexMusicModPatcher'].some(keyword => line.includes(keyword)))
             return processes.map(line => {
                 const parts = line.split(' ');
                 const pid = parseInt(parts[0], 10);

--- a/src/main/modules/utils.js
+++ b/src/main/modules/utils.js
@@ -41,6 +41,20 @@ export async function getYandexMusicProcesses() {
             logger.error('Error retrieving Yandex Music processes on Mac:', error)
             return []
         }
+    } else if (process.platform === "linux") {
+        try {
+            const command = `pgrep -fa "yandexmusic"`
+            const { stdout } = await execAsync(command, { encoding: 'utf8' })
+            const processes = stdout.split('\n').filter(line => line.trim() !== '').filter(line => !line.includes('pgrep'))
+            return processes.map(line => {
+                const parts = line.split(' ');
+                const pid = parseInt(parts[0], 10);
+                return { pid };
+            }).filter(proc => !isNaN(proc.pid));
+        } catch (error) {
+            logger.error('Error retrieving Yandex Music processes on Linux:', error)
+            return []
+        }
     } else {
         try {
             const command = `tasklist /FI "IMAGENAME eq Яндекс Музыка.exe" /FO CSV /NH`


### PR DESCRIPTION
Полная реализация поддержки патчера на Linux дистрибутивах. При выполнении копирования ASAR в директорию /opt, у пользователя появляется окно ввода пароля.

Проверенно на Ubuntu 24.04, так-же должно работать на всех Debian-основанных дистрибутивах. RHEL-основанные дистрибутивы не проверялись, но в теории должны так-же функционировать.

Fixes #8 