### PR TITLE
[Linux] Displaying of executable command in pkexec dialog window

### DIFF
--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -236,7 +236,7 @@ async function copyFile(target, dest) {
         await fso.promises.copyFile(target, dest);
     } catch (error) {
         if (process.platform === 'linux' && error.code === 'EACCES') {
-            await execFileAsync('pkexec', ['cp', target, dest]);
+            await execFileAsync('pkexec', ['cp', `"${target}"`, `"${dest}"`]);
         } else {
             logger.error('File copying failed:', error);
         }


### PR DESCRIPTION
До безумия простое решение проблемы, когда вместо исполняемой команды, `pkexec` отображал ошибку `Invalid UTF-8`. Даже как-то стыдно что сразу не додумался до этого, но видимо тогда мой мозг уже хотел отдыхать где-то на Бали :)

До фикса
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cb5b3596-38ee-4bc5-ad93-f554e91d0b23" />

После фикса
<img width="400" alt="image" src="https://github.com/user-attachments/assets/14173660-66eb-418d-aac6-85c26803ceec" />
