### PR TITLE
[Linux] Path encoding in copyFile and createDirIfNotExist functions

### DIFF
--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -251,7 +251,8 @@ async function createDirIfNotExist(target) {
             await fsp.mkdir(target);
         } catch (error) {
             if (process.platform === 'linux' && error.code === 'EACCES') {
-                await execFileAsync('pkexec', ['mkdir', '-p', target]);
+                const encodedTarget = `'${target.replace(/'/g, "'\\''")}'`;
+                await execFileAsync('pkexec', ['bash', '-c', `mkdir -p ${encodedTarget}`]);
             } else {
                 logger.error('Directory creation failed:', error)
             }

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -236,7 +236,9 @@ async function copyFile(target, dest) {
         await fso.promises.copyFile(target, dest);
     } catch (error) {
         if (process.platform === 'linux' && error.code === 'EACCES') {
-            await execFileAsync('pkexec', ['cp', `"${target}"`, `"${dest}"`]);
+            const encodedTarget = `'${target.replace(/'/g, "'\\''")}'`;
+            const encodedDest = `'${dest.replace(/'/g, "'\\''")}'`;
+            await execFileAsync('pkexec', ['bash', '-c', `cp ${encodedTarget} ${encodedDest}`]);
         } else {
             logger.error('File copying failed:', error);
         }

--- a/src/main/modules/patcher.js
+++ b/src/main/modules/patcher.js
@@ -236,9 +236,9 @@ async function copyFile(target, dest) {
         await fso.promises.copyFile(target, dest);
     } catch (error) {
         if (process.platform === 'linux' && error.code === 'EACCES') {
-            const encodedTarget = `'${target.replace(/'/g, "'\\''")}'`;
-            const encodedDest = `'${dest.replace(/'/g, "'\\''")}'`;
-            await execFileAsync('pkexec', ['bash', '-c', `cp ${encodedTarget} ${encodedDest}`]);
+            const encodedTarget = target.replaceAll("'", "\\'");
+            const encodedDest = dest.replaceAll("'", "\\'");
+            await execFileAsync('pkexec', ['bash', '-c', `cp '${encodedTarget}' '${encodedDest}'`]);
         } else {
             logger.error('File copying failed:', error);
         }
@@ -251,8 +251,8 @@ async function createDirIfNotExist(target) {
             await fsp.mkdir(target);
         } catch (error) {
             if (process.platform === 'linux' && error.code === 'EACCES') {
-                const encodedTarget = `'${target.replace(/'/g, "'\\''")}'`;
-                await execFileAsync('pkexec', ['bash', '-c', `mkdir -p ${encodedTarget}`]);
+                const encodedTarget = target.replaceAll("'", "\\'");
+                await execFileAsync('pkexec', ['bash', '-c', `mkdir -p '${encodedTarget}'`]);
             } else {
                 logger.error('Directory creation failed:', error)
             }


### PR DESCRIPTION
Прошлый PR содержал серьёзную ошибку, из-за которой двойные кавычки интерпретировались как часть пути. Из‑за этого патчер пытался скопировать не `app.asar`, а `app.asar"`, которого не существует.

Теперь пути в переменных `target` и `dest` оборачиваются в одинарные кавычки, а все одинарные кавычки внутри пути экранируются обратным слэшем. Это сделано для того, чтобы избежать ошибки `Invalid UTF-8` при вызове pkexec. Кроме того, явно используется оболочка bash для корректного выполнения команды.

Фикс протестирован на Debian 13: проверено от момента вызова диалогового окна с запросом пароля до окончания работы патчера.

P.S. Извиняюсь за прошлый PR, который, по сути, сломал то, что работало. Наглядный пример, почему нужно тестировать полностью, а не только то, что ты фиксил.
